### PR TITLE
fix(nabu.web.page.core): pass bundlePath to cssWithAris in aris-defin…

### DIFF
--- a/v2/component/public/pages/aris-definitions.glue
+++ b/v2/component/public/pages/aris-definitions.glue
@@ -1,4 +1,5 @@
-aris = cssWithAris(compile: false)/result
+bundlePath = "repository:" + script.environment("webApplicationId") + ":/private/provided/bundle.json"
+aris = cssWithAris(compile: false, bundlePath: bundlePath)/result
 
 optionCleaner = lambda
 	option ?= null


### PR DESCRIPTION
…itions

Resolve webApplicationId via script.environment() at page scope and pass bundlePath explicitly so aris-definitions works under glue v2.